### PR TITLE
Set Content-Type HTTP header to application/json

### DIFF
--- a/FeathersSwiftRest/Core/RestProvider.swift
+++ b/FeathersSwiftRest/Core/RestProvider.swift
@@ -146,6 +146,7 @@ final public class RestProvider: Provider {
         if let accessToken = endpoint.accessToken {
             urlRequest.allHTTPHeaderFields = [endpoint.authenticationConfiguration.header: accessToken]
         }
+        urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpBody = endpoint.method.data != nil ? try? JSONSerialization.data(withJSONObject: endpoint.method.data!, options: []) : nil
         return urlRequest
     }


### PR DESCRIPTION
Hi !

Currently the REST Provider send "x-www-form-urlencoded" requests with a JSON format.
The feathersjs server tries to decode the body with a "x-www-form-urlencoded" format but with a body in JSON format.
Communication with the server feathersjs is totally incompatible.

Best regards.